### PR TITLE
[Add-MemberId-Filter] 멤버 id를 요청 헤더에 추가

### DIFF
--- a/src/main/java/cloud/zipbob/edgeservice/auth/PrincipalDetails.java
+++ b/src/main/java/cloud/zipbob/edgeservice/auth/PrincipalDetails.java
@@ -29,7 +29,8 @@ public class PrincipalDetails extends Member implements UserDetails, OAuth2User 
         this.attributes = attributes;
     }
 
-    private PrincipalDetails(String email, String role) {
+    private PrincipalDetails(Long memberId, String email, String role) {
+        this.id = memberId;
         this.email = email;
         this.role = role;
     }
@@ -48,8 +49,8 @@ public class PrincipalDetails extends Member implements UserDetails, OAuth2User 
         return new PrincipalDetails(member, attributes);
     }
 
-    public static PrincipalDetails of(String email, String role) {
-        return new PrincipalDetails(email, role);
+    public static PrincipalDetails of(Long memberId, String email, String role) {
+        return new PrincipalDetails(memberId, email, role);
     }
 
     @Override

--- a/src/main/java/cloud/zipbob/edgeservice/auth/filter/AddMemberIdHeaderFilter.java
+++ b/src/main/java/cloud/zipbob/edgeservice/auth/filter/AddMemberIdHeaderFilter.java
@@ -1,0 +1,53 @@
+package cloud.zipbob.edgeservice.auth.filter;
+
+import cloud.zipbob.edgeservice.auth.PrincipalDetails;
+import cloud.zipbob.edgeservice.global.MutableHttpServletRequest;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+public class AddMemberIdHeaderFilter implements Filter {
+
+    private static final List<String> EXCLUDED_PATHS = List.of("/auth/reissue", "/members/nickname-check");
+
+    @Override
+    public void doFilter(jakarta.servlet.ServletRequest request,
+                         jakarta.servlet.ServletResponse response,
+                         FilterChain chain) throws IOException, ServletException {
+
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+        String requestURI = httpRequest.getRequestURI();
+        if (shouldNotFilter(requestURI)) {
+            log.info("Request URI excluded from AddMemberIdHeaderFilter: {}", requestURI);
+            chain.doFilter(request, response);
+            return;
+        }
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()) {
+            PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
+            Long memberId = principalDetails.getId();
+            MutableHttpServletRequest mutableRequest = new MutableHttpServletRequest(httpRequest);
+            mutableRequest.addHeader("X-Member-Id", String.valueOf(memberId));
+            log.info("Member Id Header Set Complete :{}", memberId);
+            chain.doFilter(mutableRequest, httpResponse);
+            return;
+        }
+        chain.doFilter(request, response);
+    }
+
+    private boolean shouldNotFilter(String requestURI) {
+        return EXCLUDED_PATHS.stream().anyMatch(requestURI::startsWith);
+    }
+}

--- a/src/main/java/cloud/zipbob/edgeservice/auth/filter/JwtVerificationFilter.java
+++ b/src/main/java/cloud/zipbob/edgeservice/auth/filter/JwtVerificationFilter.java
@@ -79,7 +79,8 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
     }
 
     @Override
-    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        log.info("Request URI excluded from JwtVerificationFilter");
         return EXCLUDED_PATHS.stream().anyMatch(exclude -> exclude.equalsIgnoreCase(request.getServletPath()));
     }
 

--- a/src/main/java/cloud/zipbob/edgeservice/config/GatewayFilterConfig.java
+++ b/src/main/java/cloud/zipbob/edgeservice/config/GatewayFilterConfig.java
@@ -1,0 +1,19 @@
+package cloud.zipbob.edgeservice.config;
+
+import cloud.zipbob.edgeservice.auth.filter.AddMemberIdHeaderFilter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GatewayFilterConfig {
+
+    @Bean
+    public FilterRegistrationBean<AddMemberIdHeaderFilter> addMemberIdHeaderFilter() {
+        FilterRegistrationBean<AddMemberIdHeaderFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(new AddMemberIdHeaderFilter());
+        registrationBean.addUrlPatterns("/*");
+        registrationBean.setOrder(2);
+        return registrationBean;
+    }
+}

--- a/src/main/java/cloud/zipbob/edgeservice/global/MutableHttpServletRequest.java
+++ b/src/main/java/cloud/zipbob/edgeservice/global/MutableHttpServletRequest.java
@@ -1,0 +1,46 @@
+package cloud.zipbob.edgeservice.global;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+
+import java.util.*;
+
+public class MutableHttpServletRequest extends HttpServletRequestWrapper {
+
+    private final Map<String, String> customHeaders = new HashMap<>();
+
+    public MutableHttpServletRequest(HttpServletRequest request) {
+        super(request);
+    }
+
+    public void addHeader(String name, String value) {
+        customHeaders.put(name, value);
+    }
+
+    @Override
+    public String getHeader(String name) {
+        String headerValue = customHeaders.get(name);
+        if (headerValue != null) {
+            return headerValue;
+        }
+        return super.getHeader(name);
+    }
+
+    @Override
+    public Enumeration<String> getHeaderNames() {
+        Set<String> headerNames = new HashSet<>(customHeaders.keySet());
+        Enumeration<String> originalHeaderNames = super.getHeaderNames();
+        while (originalHeaderNames.hasMoreElements()) {
+            headerNames.add(originalHeaderNames.nextElement());
+        }
+        return Collections.enumeration(headerNames);
+    }
+
+    @Override
+    public Enumeration<String> getHeaders(String name) {
+        if (customHeaders.containsKey(name)) {
+            return Collections.enumeration(Collections.singletonList(customHeaders.get(name)));
+        }
+        return super.getHeaders(name);
+    }
+}

--- a/src/test/java/cloud/zipbob/edgeservice/EdgeServiceApplicationTests.java
+++ b/src/test/java/cloud/zipbob/edgeservice/EdgeServiceApplicationTests.java
@@ -2,8 +2,10 @@ package cloud.zipbob.edgeservice;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class EdgeServiceApplicationTests {
 
     @Test

--- a/src/test/java/cloud/zipbob/edgeservice/auth/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/cloud/zipbob/edgeservice/auth/jwt/JwtTokenProviderTest.java
@@ -103,6 +103,7 @@ class JwtTokenProviderTest {
     void getAuthentication_ShouldReturnAuthenticationFromToken() {
         // given
         Member member = Member.builder()
+                .id(1L)
                 .email("test@example.com")
                 .password("password")
                 .role(Role.USER)


### PR DESCRIPTION
## 🌲 작업한 브랜치
- feature/add-memberId-filter

## 📚 작업한 내용
### MemberId를 기존 JWT Token의 클레임에 추가
- 기존에 권한만 있었던 클레임에 member ID의 값도 추가하였습니다.

### GateWay global filter를 구현
- 필터를 통해 요청 헤더에 인증된 memberId를 넣도록 구현하였습니다.

## ❗이슈 사항

## ⭐ 연관된 이슈
Close #12 
## 🤔 궁금한 점