### PR TITLE
[hotfix/config] RabbitMQ 설정 Cofig-repo로 이전

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,11 +5,6 @@ spring:
     active: local
   config:
     import: "configserver:"
-  rabbitmq:
-    host: ${RABBITMQ_HOST}
-    port: ${RABBITMQ_PORT}
-    username: ${RABBITMQ_USERNAME}
-    password: ${RABBITMQ_PASSWORD}
   cloud:
     config:
       uri: http://localhost:8888


### PR DESCRIPTION
## 🌲 작업한 브랜치
- hotfix/config

## 📚 작업한 내용
### RabbitMQ에 대한 설정을 Config-Repo로 이전하였습니다.
- Spring Cloud Bus 설정으로 인하여 RabbitMQ를 외부 yaml 파일에서 직접 주입해줘야 한다고 생각하였는데, Confg repo에 넣어 관리하여도 Cloud Bus에 대한 queue가 생성되는 것을 확인하였습니다.

## ❗이슈 사항

## ⭐ 연관된 이슈

## 🤔 궁금한 점