### PR TITLE
[feature/testContainer] 레시피 추천 응답 추가

### DIFF
--- a/src/main/java/cloud/zipbob/edgeservice/api/HomeController.java
+++ b/src/main/java/cloud/zipbob/edgeservice/api/HomeController.java
@@ -1,0 +1,14 @@
+package cloud.zipbob.edgeservice.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HomeController {
+
+    @GetMapping("/")
+    public ResponseEntity<String> home() {
+        return ResponseEntity.ok("Zipbob Service Backend Server");
+    }
+}

--- a/src/main/java/cloud/zipbob/edgeservice/api/MemberController.java
+++ b/src/main/java/cloud/zipbob/edgeservice/api/MemberController.java
@@ -1,13 +1,16 @@
 package cloud.zipbob.edgeservice.api;
 
 import cloud.zipbob.edgeservice.auth.PrincipalDetails;
+import cloud.zipbob.edgeservice.auth.jwt.JwtTokenProvider;
 import cloud.zipbob.edgeservice.domain.member.request.MemberUpdateRequest;
 import cloud.zipbob.edgeservice.domain.member.request.MemberWithdrawRequest;
 import cloud.zipbob.edgeservice.domain.member.request.OAuth2JoinRequest;
+import cloud.zipbob.edgeservice.domain.member.request.TestJoinRequest;
 import cloud.zipbob.edgeservice.domain.member.response.MemberUpdateResponse;
 import cloud.zipbob.edgeservice.domain.member.response.MemberWithdrawResponse;
 import cloud.zipbob.edgeservice.domain.member.response.MyInfoResponse;
 import cloud.zipbob.edgeservice.domain.member.response.OAuth2JoinResponse;
+import cloud.zipbob.edgeservice.domain.member.response.TestJoinResponse;
 import cloud.zipbob.edgeservice.domain.member.service.MemberService;
 import cloud.zipbob.edgeservice.global.Responder;
 import cloud.zipbob.edgeservice.global.email.EmailService;
@@ -15,7 +18,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/members")
@@ -24,6 +34,7 @@ public class MemberController {
 
     private final MemberService memberService;
     private final EmailService emailService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @PatchMapping("/update")
     @PreAuthorize("hasAnyAuthority('ROLE_USER', 'ROLE_ADMIN')")
@@ -35,7 +46,8 @@ public class MemberController {
 
     @PatchMapping("/oauth2/join")
     @PreAuthorize("hasAnyAuthority('ROLE_GUEST')")
-    public ResponseEntity<OAuth2JoinResponse> join(@AuthenticationPrincipal PrincipalDetails user, @RequestBody final OAuth2JoinRequest request) {
+    public ResponseEntity<OAuth2JoinResponse> join(@AuthenticationPrincipal PrincipalDetails user,
+                                                   @RequestBody final OAuth2JoinRequest request) {
         OAuth2JoinResponse response = memberService.oauth2Join(request, user.getUsername());
         emailService.sendEmailRequest(user.getUsername(), request.nickname(), "welcome");
         return Responder.success(response);
@@ -62,4 +74,12 @@ public class MemberController {
         boolean result = memberService.checkNickname(nickname);
         return Responder.success(result);
     }
+
+    //TODO test 후 배포할 때 제거 필수 (url 필터 제외도 제거)
+    @PostMapping("/test/join")
+    public ResponseEntity<TestJoinResponse> testJoin(@RequestBody final TestJoinRequest request) {
+        TestJoinResponse response = memberService.testJoin(request.email());
+        return Responder.success(response);
+    }
+
 }

--- a/src/main/java/cloud/zipbob/edgeservice/api/RecipeController.java
+++ b/src/main/java/cloud/zipbob/edgeservice/api/RecipeController.java
@@ -1,0 +1,35 @@
+package cloud.zipbob.edgeservice.api;
+
+import cloud.zipbob.edgeservice.global.recipe.RecipeConsumer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequestMapping("/recipes")
+@RequiredArgsConstructor
+public class RecipeController {
+
+    private final RecipeConsumer recipeConsumer;
+
+    @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter streamRecipes() {
+        SseEmitter sseEmitter = new SseEmitter();
+        new Thread(() -> {
+            try {
+                while (true) {
+                    String recipe = recipeConsumer.getRecipe();
+                    if (recipe != null) {
+                        sseEmitter.send(recipe);
+                    }
+                }
+            } catch (Exception e) {
+                sseEmitter.completeWithError(e);
+            }
+        }).start();
+        return sseEmitter;
+    }
+}

--- a/src/main/java/cloud/zipbob/edgeservice/auth/filter/AddMemberIdHeaderFilter.java
+++ b/src/main/java/cloud/zipbob/edgeservice/auth/filter/AddMemberIdHeaderFilter.java
@@ -16,7 +16,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 @Slf4j
 public class AddMemberIdHeaderFilter implements Filter {
 
-    private static final List<String> EXCLUDED_PATHS = List.of("/auth/reissue", "/members/nickname-check", "/");
+    private static final List<String> EXCLUDED_PATHS = List.of("/auth/reissue", "/members/nickname-check", "/",
+            "/members/test/join");
 
     @Override
     public void doFilter(jakarta.servlet.ServletRequest request,

--- a/src/main/java/cloud/zipbob/edgeservice/auth/filter/AddMemberIdHeaderFilter.java
+++ b/src/main/java/cloud/zipbob/edgeservice/auth/filter/AddMemberIdHeaderFilter.java
@@ -7,17 +7,16 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-import java.io.IOException;
-import java.util.List;
-
 @Slf4j
 public class AddMemberIdHeaderFilter implements Filter {
 
-    private static final List<String> EXCLUDED_PATHS = List.of("/auth/reissue", "/members/nickname-check");
+    private static final List<String> EXCLUDED_PATHS = List.of("/auth/reissue", "/members/nickname-check", "/");
 
     @Override
     public void doFilter(jakarta.servlet.ServletRequest request,

--- a/src/main/java/cloud/zipbob/edgeservice/config/SecurityConfig.java
+++ b/src/main/java/cloud/zipbob/edgeservice/config/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
                         .accessDeniedHandler(customAccessDeniedHandler))
                 .authorizeHttpRequests(authorizeRequests -> authorizeRequests
                         .requestMatchers("/", "/auth/reissue",
-                                "members/nickname-check/**", "/actuator/**")
+                                "members/nickname-check/**", "/actuator/**", "/members/test/join")
                         .permitAll()
                         .anyRequest().authenticated())
                 .oauth2Login((oauth2Login) ->

--- a/src/main/java/cloud/zipbob/edgeservice/config/SecurityConfig.java
+++ b/src/main/java/cloud/zipbob/edgeservice/config/SecurityConfig.java
@@ -7,6 +7,8 @@ import cloud.zipbob.edgeservice.global.redis.RedisService;
 import cloud.zipbob.edgeservice.oauth2.CustomOAuth2MemberService;
 import cloud.zipbob.edgeservice.oauth2.handler.OAuth2LoginFailureHandler;
 import cloud.zipbob.edgeservice.oauth2.handler.OAuth2LoginSuccessHandler;
+import java.util.Arrays;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,9 +23,6 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
-import java.util.Arrays;
-import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -49,14 +48,13 @@ public class SecurityConfig {
                 .exceptionHandling(exception -> exception
                         .accessDeniedHandler(customAccessDeniedHandler))
                 .authorizeHttpRequests(authorizeRequests -> authorizeRequests
-                        .requestMatchers("/auth/reissue",
-                                "members/nickname-check/**", "/swagger-ui/**",
-                                "/api-docs/**", "/actuator/**")
-                        //TODO actuator 관련 수정
+                        .requestMatchers("/", "/auth/reissue",
+                                "members/nickname-check/**", "/actuator/**")
                         .permitAll()
                         .anyRequest().authenticated())
                 .oauth2Login((oauth2Login) ->
                         oauth2Login
+                                .loginPage("/")
                                 .userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig.userService(
                                         customOAuth2MemberService))
                                 .successHandler(oAuth2LoginSuccessHandler)
@@ -65,7 +63,8 @@ public class SecurityConfig {
                 .logout(logout -> logout.deleteCookies("JSESSIONID")
                         .logoutUrl("/auth/logout"));
 
-        http.addFilterBefore(new JwtVerificationFilter(jwtTokenProvider, redisService), UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(new JwtVerificationFilter(jwtTokenProvider, redisService),
+                UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/cloud/zipbob/edgeservice/domain/member/request/TestJoinRequest.java
+++ b/src/main/java/cloud/zipbob/edgeservice/domain/member/request/TestJoinRequest.java
@@ -1,0 +1,5 @@
+package cloud.zipbob.edgeservice.domain.member.request;
+
+//TODO test 후 배포할 때 제거 필수
+public record TestJoinRequest(String email) {
+}

--- a/src/main/java/cloud/zipbob/edgeservice/domain/member/response/TestJoinResponse.java
+++ b/src/main/java/cloud/zipbob/edgeservice/domain/member/response/TestJoinResponse.java
@@ -1,0 +1,24 @@
+package cloud.zipbob.edgeservice.domain.member.response;
+
+import cloud.zipbob.edgeservice.domain.member.Member;
+import cloud.zipbob.edgeservice.domain.member.Role;
+import cloud.zipbob.edgeservice.oauth2.SocialType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+//TODO test 후 배포할 때 제거 필수
+@Getter
+@AllArgsConstructor
+public class TestJoinResponse {
+    private Long id;
+    private String email;
+    private Role role;
+    private SocialType socialType;
+    private String accessToken;
+    private String refreshToken;
+
+    public static TestJoinResponse of(Member member, String accessToken, String refreshToken) {
+        return new TestJoinResponse(member.getId(), member.getEmail(), member.getRole(),
+                member.getSocialType(), accessToken, refreshToken);
+    }
+}

--- a/src/main/java/cloud/zipbob/edgeservice/domain/member/service/MemberService.java
+++ b/src/main/java/cloud/zipbob/edgeservice/domain/member/service/MemberService.java
@@ -7,6 +7,7 @@ import cloud.zipbob.edgeservice.domain.member.response.MemberUpdateResponse;
 import cloud.zipbob.edgeservice.domain.member.response.MemberWithdrawResponse;
 import cloud.zipbob.edgeservice.domain.member.response.MyInfoResponse;
 import cloud.zipbob.edgeservice.domain.member.response.OAuth2JoinResponse;
+import cloud.zipbob.edgeservice.domain.member.response.TestJoinResponse;
 
 public interface MemberService {
     MemberUpdateResponse update(MemberUpdateRequest request, String email);
@@ -18,4 +19,7 @@ public interface MemberService {
     MyInfoResponse myInfo(String email);
 
     boolean checkNickname(String nickname);
+
+    //TODO test 후 배포할 때 제거 필수
+    TestJoinResponse testJoin(String email);
 }

--- a/src/main/java/cloud/zipbob/edgeservice/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/cloud/zipbob/edgeservice/domain/member/service/MemberServiceImpl.java
@@ -1,6 +1,11 @@
 package cloud.zipbob.edgeservice.domain.member.service;
 
+import cloud.zipbob.edgeservice.auth.PrincipalDetails;
+import cloud.zipbob.edgeservice.auth.dto.TokenDto;
+import cloud.zipbob.edgeservice.auth.jwt.JwtTokenProperties;
+import cloud.zipbob.edgeservice.auth.jwt.JwtTokenProvider;
 import cloud.zipbob.edgeservice.domain.member.Member;
+import cloud.zipbob.edgeservice.domain.member.Role;
 import cloud.zipbob.edgeservice.domain.member.exception.MemberException;
 import cloud.zipbob.edgeservice.domain.member.exception.MemberExceptionType;
 import cloud.zipbob.edgeservice.domain.member.repository.MemberRepository;
@@ -11,6 +16,10 @@ import cloud.zipbob.edgeservice.domain.member.response.MemberUpdateResponse;
 import cloud.zipbob.edgeservice.domain.member.response.MemberWithdrawResponse;
 import cloud.zipbob.edgeservice.domain.member.response.MyInfoResponse;
 import cloud.zipbob.edgeservice.domain.member.response.OAuth2JoinResponse;
+import cloud.zipbob.edgeservice.domain.member.response.TestJoinResponse;
+import cloud.zipbob.edgeservice.global.redis.RedisService;
+import cloud.zipbob.edgeservice.oauth2.SocialType;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +30,9 @@ import org.springframework.transaction.annotation.Transactional;
 // TODO 관리자 전용 api 제작하기 (멤버 삭제)
 public class MemberServiceImpl implements MemberService {
     private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RedisService redisService;
+    private final JwtTokenProperties jwtTokenProperties;
 
     @Override
     public MemberUpdateResponse update(MemberUpdateRequest request, String email) {
@@ -66,5 +78,30 @@ public class MemberServiceImpl implements MemberService {
     @Override
     public boolean checkNickname(String nickname) {
         return memberRepository.findByNickname(nickname).isPresent();
+    }
+
+    //TODO test 후 배포할 때 제거 필수
+    @Override
+    public TestJoinResponse testJoin(String email) {
+        if (memberRepository.findByEmail(email).isPresent()) {
+            throw new MemberException(MemberExceptionType.ALREADY_EXIST_EMAIL);
+        }
+        String password = "{bcrypt}$2a$10$N9qo8uLO2XxS5Tp25KXZy.sqzotZ9dhJdV32wBd4YwyvZ1CzzZ9cK";
+        Member member = Member.builder()
+                .socialType(SocialType.KAKAO)
+                .socialId("123456789")
+                .email(email)
+                .password(password)
+                .role(Role.GUEST)
+                .build();
+        memberRepository.save(member);
+        PrincipalDetails principalDetails = new PrincipalDetails(member);
+        TokenDto tokenDto = jwtTokenProvider.generateTokenDto(principalDetails);
+        String accessToken = tokenDto.getAccessToken();
+        String refreshToken = tokenDto.getRefreshToken();
+        long refreshTokenExpirationPeriod = jwtTokenProperties.getRefreshExpiration();
+        redisService.setValues(member.getEmail(), refreshToken,
+                Duration.ofMillis(refreshTokenExpirationPeriod));
+        return TestJoinResponse.of(member, accessToken, tokenDto.getRefreshToken());
     }
 }

--- a/src/main/java/cloud/zipbob/edgeservice/global/recipe/RecipeConsumer.java
+++ b/src/main/java/cloud/zipbob/edgeservice/global/recipe/RecipeConsumer.java
@@ -1,0 +1,32 @@
+package cloud.zipbob.edgeservice.global.recipe;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RecipeConsumer {
+
+    private final BlockingQueue<String> recipeQueue = new LinkedBlockingQueue<>();
+
+    //TODO 큐 이름 수정
+    @RabbitListener(queues = "recipe.queue")
+    public void receiveRecipe(String recipe) {
+        log.info("레시피를 받았습니다.");
+        try {
+            recipeQueue.put(recipe);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            System.err.println("Thread interrupted while adding recipe to the queue");
+        }
+    }
+
+    public String getRecipe() throws InterruptedException {
+        return recipeQueue.take();
+    }
+}

--- a/src/test/java/cloud/zipbob/edgeservice/global/recipe/RecipeConsumerTest.java
+++ b/src/test/java/cloud/zipbob/edgeservice/global/recipe/RecipeConsumerTest.java
@@ -1,0 +1,20 @@
+package cloud.zipbob.edgeservice.global.recipe;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RecipeConsumerTest {
+
+    @Test
+    @DisplayName("레시피 받기")
+    public void testReceiveRecipe() throws InterruptedException {
+        RecipeConsumer consumer = new RecipeConsumer();
+        String recipeMessage = "{\"title\":\"Pasta\", \"ingredients\":[\"noodles\",\"sauce\"]}";
+        consumer.receiveRecipe(recipeMessage);
+
+        String result = consumer.getRecipe();
+        assertEquals(recipeMessage, result);
+    }
+}


### PR DESCRIPTION
## 🌲 작업한 브랜치
- feature/testContainer

## 📚 작업한 내용
### AI 서비스에서 레시피를 큐에 등록하면 가져오는 로직 추가
- Rabbit Listener를 통해 AI 서비스가 큐에 레시피를 등록하면 이를 가져오도록 하였습니다.

### SSE 연결을 통한 클라이언트에 레시피 제공
- 클라이언트와 SSE 연결을 하여 실시간으로 레시피를 전달 할 수 있도록 하였습니다.

## ❗이슈 사항

## ⭐ 연관된 이슈
Close #20 

## 🤔 궁금한 점