### PR TITLE
[featire/mariadb-master-slave] Mariadb 마스터, 슬레이브 설정 추가

### DIFF
--- a/src/main/java/cloud/zipbob/edgeservice/api/MemberController.java
+++ b/src/main/java/cloud/zipbob/edgeservice/api/MemberController.java
@@ -1,7 +1,6 @@
 package cloud.zipbob.edgeservice.api;
 
 import cloud.zipbob.edgeservice.auth.PrincipalDetails;
-import cloud.zipbob.edgeservice.auth.jwt.JwtTokenProvider;
 import cloud.zipbob.edgeservice.domain.member.request.MemberUpdateRequest;
 import cloud.zipbob.edgeservice.domain.member.request.MemberWithdrawRequest;
 import cloud.zipbob.edgeservice.domain.member.request.OAuth2JoinRequest;
@@ -34,7 +33,6 @@ public class MemberController {
 
     private final MemberService memberService;
     private final EmailService emailService;
-    private final JwtTokenProvider jwtTokenProvider;
 
     @PatchMapping("/update")
     @PreAuthorize("hasAnyAuthority('ROLE_USER', 'ROLE_ADMIN')")
@@ -65,7 +63,7 @@ public class MemberController {
     @GetMapping("/myInfo")
     @PreAuthorize("hasAnyAuthority('ROLE_USER', 'ROLE_ADMIN')")
     public ResponseEntity<MyInfoResponse> myInfo(@AuthenticationPrincipal PrincipalDetails user) {
-        MyInfoResponse response = memberService.myInfo(user.getUsername());
+        MyInfoResponse response = memberService.getMyInfo(user.getUsername());
         return Responder.success(response);
     }
 

--- a/src/main/java/cloud/zipbob/edgeservice/config/DataSourceConfig.java
+++ b/src/main/java/cloud/zipbob/edgeservice/config/DataSourceConfig.java
@@ -1,0 +1,98 @@
+package cloud.zipbob.edgeservice.config;
+
+import cloud.zipbob.edgeservice.global.datasource.RoutingDataSource;
+import com.zaxxer.hikari.HikariDataSource;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Configuration
+@Slf4j
+@EnableTransactionManagement
+@RequiredArgsConstructor
+@EnableJpaRepositories(
+        basePackages = "cloud.zipbob.edgeservice.domain.member.repository",
+        entityManagerFactoryRef = "masterEntityManagerFactory",
+        transactionManagerRef = "masterTransactionManager"
+)
+public class DataSourceConfig {
+
+    private final MariaDbProperties mariaDbProperties;
+
+    @Bean(name = "masterDataSource")
+    public DataSource masterDataSource() {
+        log.info("Initializing Master DataSource");
+        HikariDataSource dataSource = new HikariDataSource();
+        dataSource.setJdbcUrl(mariaDbProperties.getMaster().getUrl());
+        dataSource.setDriverClassName(mariaDbProperties.getMaster().getDriverClassName());
+        dataSource.setUsername(mariaDbProperties.getMaster().getUsername());
+        dataSource.setPassword(mariaDbProperties.getMaster().getPassword());
+        return dataSource;
+    }
+
+    @Bean(name = "slaveDataSource")
+    public DataSource slaveDataSource() {
+        log.info("Initializing Slave DataSource");
+        HikariDataSource dataSource = new HikariDataSource();
+        dataSource.setJdbcUrl(mariaDbProperties.getSlave().getUrl());
+        dataSource.setDriverClassName(mariaDbProperties.getSlave().getDriverClassName());
+        dataSource.setUsername(mariaDbProperties.getSlave().getUsername());
+        dataSource.setPassword(mariaDbProperties.getSlave().getPassword());
+        return dataSource;
+    }
+
+    @Bean
+    @Primary
+    public DataSource dataSource() {
+        log.info("Initializing Routing DataSource");
+        RoutingDataSource routingDataSource = new RoutingDataSource();
+
+        Map<Object, Object> targetDataSources = new HashMap<>();
+        targetDataSources.put("master", masterDataSource());
+        targetDataSources.put("slave", slaveDataSource());
+
+        routingDataSource.setTargetDataSources(targetDataSources);
+        routingDataSource.setDefaultTargetDataSource(masterDataSource());
+
+        return routingDataSource;
+    }
+
+
+    @Bean(name = "masterEntityManagerFactory")
+    public LocalContainerEntityManagerFactoryBean masterEntityManagerFactory() {
+        LocalContainerEntityManagerFactoryBean factory = new LocalContainerEntityManagerFactoryBean();
+        factory.setDataSource(dataSource());
+        factory.setPackagesToScan("cloud.zipbob.edgeservice.domain.member");
+        factory.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
+        factory.setJpaPropertyMap(hibernateProperties());
+        return factory;
+    }
+
+    @Bean(name = "masterTransactionManager")
+    public PlatformTransactionManager masterTransactionManager(
+            LocalContainerEntityManagerFactoryBean masterEntityManagerFactory) {
+        return new JpaTransactionManager(Objects.requireNonNull(masterEntityManagerFactory.getObject()));
+    }
+
+    private Map<String, Object> hibernateProperties() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("hibernate.hbm2ddl.auto", "update");
+        properties.put("hibernate.show_sql", true);
+        properties.put("hibernate.format_sql", true);
+        properties.put("hibernate.use_sql_comments", true);
+        properties.put("hibernate.dialect", "org.hibernate.dialect.MariaDBDialect");
+        return properties;
+    }
+}

--- a/src/main/java/cloud/zipbob/edgeservice/config/MariaDbProperties.java
+++ b/src/main/java/cloud/zipbob/edgeservice/config/MariaDbProperties.java
@@ -1,0 +1,27 @@
+package cloud.zipbob.edgeservice.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Setter
+@Getter
+@Configuration
+@ConfigurationProperties(prefix = "spring.datasource")
+public class MariaDbProperties {
+
+    private DataSourceProperties master;
+    private DataSourceProperties slave;
+
+    @Setter
+    @Getter
+    public static class DataSourceProperties {
+        private String url;
+        private String driverClassName;
+        private String username;
+        private String password;
+
+    }
+
+}

--- a/src/main/java/cloud/zipbob/edgeservice/domain/member/service/MemberService.java
+++ b/src/main/java/cloud/zipbob/edgeservice/domain/member/service/MemberService.java
@@ -16,7 +16,7 @@ public interface MemberService {
 
     MemberWithdrawResponse withdraw(MemberWithdrawRequest request, String email);
 
-    MyInfoResponse myInfo(String email);
+    MyInfoResponse getMyInfo(String email);
 
     boolean checkNickname(String nickname);
 

--- a/src/main/java/cloud/zipbob/edgeservice/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/cloud/zipbob/edgeservice/domain/member/service/MemberServiceImpl.java
@@ -25,7 +25,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 // TODO 관리자 전용 api 제작하기 (멤버 삭제)
 public class MemberServiceImpl implements MemberService {
@@ -35,6 +34,7 @@ public class MemberServiceImpl implements MemberService {
     private final JwtTokenProperties jwtTokenProperties;
 
     @Override
+    @Transactional
     public MemberUpdateResponse update(MemberUpdateRequest request, String email) {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new MemberException(MemberExceptionType.MEMBER_NOT_FOUND));
@@ -46,6 +46,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    @Transactional
     public OAuth2JoinResponse oauth2Join(OAuth2JoinRequest request, String email) {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new MemberException(MemberExceptionType.MEMBER_NOT_FOUND));
@@ -58,6 +59,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    @Transactional
     public MemberWithdrawResponse withdraw(MemberWithdrawRequest request, String email) {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new MemberException(MemberExceptionType.MEMBER_NOT_FOUND));
@@ -69,13 +71,15 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public MyInfoResponse myInfo(String email) {
+    @Transactional(readOnly = true)
+    public MyInfoResponse getMyInfo(String email) {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new MemberException(MemberExceptionType.MEMBER_NOT_FOUND));
         return MyInfoResponse.of(member);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public boolean checkNickname(String nickname) {
         return memberRepository.findByNickname(nickname).isPresent();
     }

--- a/src/main/java/cloud/zipbob/edgeservice/global/datasource/DataSourceAspect.java
+++ b/src/main/java/cloud/zipbob/edgeservice/global/datasource/DataSourceAspect.java
@@ -1,0 +1,26 @@
+package cloud.zipbob.edgeservice.global.datasource;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+public class DataSourceAspect {
+
+    @Before("execution(* cloud.zipbob.edgeservice.domain.member.service.*.get*(..)) || execution(* cloud.zipbob.edgeservice.domain.member.service.*.check*(..))")
+    public void setReadDataSource() {
+        log.info("Switching to Slave DataSource");
+        DataSourceContextHolder.setDataSourceType("slave");
+    }
+
+    @Before("execution(* cloud.zipbob.edgeservice.domain.member.service.*.save*(..)) || execution(* cloud.zipbob.edgeservice.domain.member.service.*.update*(..)) || execution(* cloud.zipbob.edgeservice.domain.member.service.*.delete*(..))")
+    public void setWriteDataSource() {
+        log.info("Switching to Master DataSource");
+        DataSourceContextHolder.setDataSourceType("master");
+    }
+
+}
+

--- a/src/main/java/cloud/zipbob/edgeservice/global/datasource/DataSourceContextHolder.java
+++ b/src/main/java/cloud/zipbob/edgeservice/global/datasource/DataSourceContextHolder.java
@@ -1,0 +1,18 @@
+package cloud.zipbob.edgeservice.global.datasource;
+
+public class DataSourceContextHolder {
+    private static final ThreadLocal<String> contextHolder = new ThreadLocal<>();
+
+    public static void setDataSourceType(String dataSourceType) {
+        contextHolder.set(dataSourceType);
+    }
+
+    public static String getDataSourceType() {
+        return contextHolder.get();
+    }
+
+    public static void clearDataSourceType() {
+        contextHolder.remove();
+    }
+}
+

--- a/src/main/java/cloud/zipbob/edgeservice/global/datasource/RoutingDataSource.java
+++ b/src/main/java/cloud/zipbob/edgeservice/global/datasource/RoutingDataSource.java
@@ -1,0 +1,10 @@
+package cloud.zipbob.edgeservice.global.datasource;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+
+public class RoutingDataSource extends AbstractRoutingDataSource {
+    @Override
+    protected Object determineCurrentLookupKey() {
+        return DataSourceContextHolder.getDataSourceType();
+    }
+}

--- a/src/test/java/cloud/zipbob/edgeservice/EdgeServiceIntegrationTest.java
+++ b/src/test/java/cloud/zipbob/edgeservice/EdgeServiceIntegrationTest.java
@@ -174,7 +174,7 @@ public class EdgeServiceIntegrationTest {
         MockHttpServletResponse response = mockMvc.perform(patch("/members/update")
                         .header("Authorization", "Bearer " + accessToken)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"newNickname\": \"updatedUser\"}"))
+                        .content("{\"newNickname\": \"updatedUser2\"}"))
                 .andExpect(status().isOk())
                 .andReturn()
                 .getResponse();
@@ -189,7 +189,7 @@ public class EdgeServiceIntegrationTest {
         assertThat(jsonNode.get("email").asText()).isEqualTo("test@example.com");
 
         Member updatedMember = memberRepository.findByEmail("test@example.com").orElseThrow();
-        assertThat(updatedMember.getNickname()).isEqualTo("updatedUser");
+        assertThat(updatedMember.getNickname()).isEqualTo("updatedUser2");
     }
 
     @Test

--- a/src/test/java/cloud/zipbob/edgeservice/domain/member/service/MemberServiceImplTest.java
+++ b/src/test/java/cloud/zipbob/edgeservice/domain/member/service/MemberServiceImplTest.java
@@ -1,5 +1,14 @@
 package cloud.zipbob.edgeservice.domain.member.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import cloud.zipbob.edgeservice.domain.member.Member;
 import cloud.zipbob.edgeservice.domain.member.Role;
 import cloud.zipbob.edgeservice.domain.member.exception.MemberException;
@@ -13,6 +22,7 @@ import cloud.zipbob.edgeservice.domain.member.response.MemberWithdrawResponse;
 import cloud.zipbob.edgeservice.domain.member.response.MyInfoResponse;
 import cloud.zipbob.edgeservice.domain.member.response.OAuth2JoinResponse;
 import cloud.zipbob.edgeservice.oauth2.SocialType;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,12 +32,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceImplTest {
@@ -145,7 +149,7 @@ class MemberServiceImplTest {
         when(memberRepository.findByEmail(anyString())).thenReturn(Optional.of(member));
 
         // when
-        MyInfoResponse response = memberService.myInfo(email);
+        MyInfoResponse response = memberService.getMyInfo(email);
 
         // then
         assertEquals(member.getEmail(), response.getEmail());
@@ -163,7 +167,7 @@ class MemberServiceImplTest {
 
         // when & then
         MemberException exception = assertThrows(MemberException.class,
-                () -> memberService.myInfo(email));
+                () -> memberService.getMyInfo(email));
 
         assertEquals(MemberExceptionType.MEMBER_NOT_FOUND, exception.getExceptionType());
         verify(memberRepository, times(1)).findByEmail(anyString());


### PR DESCRIPTION
## 🌲 작업한 브랜치  
feature/mariadb-master-slave

## 📚 작업한 내용  
- **MariaDB Master-Slave 구성 추가**  
  - Master 데이터베이스에서 쓰기 작업을 수행하고, Slave 데이터베이스에서 읽기 작업을 수행하도록 설정  
  - Spring Boot에서 `RoutingDataSource`를 사용하여 Master-Slave 간의 라우팅 설정  
  - 읽기 전용 트랜잭션 시 Slave 데이터베이스로 라우팅되도록 로직 추가  
  - 애플리케이션 실행 시 Master와 Slave 데이터베이스 연결이 모두 확인되도록 설정  

- **Spring 설정 변경**  
  - `application.yml`에 Master와 Slave 데이터베이스 연결 정보를 추가  
  - `RoutingDataSource` 빈을 생성하고, AOP를 사용해 트랜잭션의 읽기 여부에 따라 동적으로 데이터 소스 선택  

## ❗이슈 사항  
- Slave 데이터베이스에 복제 지연이 발생할 경우 읽기 시점 일관성 문제가 발생할 수 있음  

## ⭐ 연관된 이슈  
Close #22 

## 🤔 궁금한 점  
- 복제 지연에 따른 데이터 일관성 문제를 해결하기 위한 전략이 필요할까요?  
